### PR TITLE
should take large icon from mipmap

### DIFF
--- a/android/LocalNotifyPlugin.java
+++ b/android/LocalNotifyPlugin.java
@@ -135,7 +135,7 @@ public class LocalNotifyPlugin extends BroadcastReceiver implements IPlugin {
 	public static void showNotification(Context context, NotificationData info) {
 		int defaults = Notification.DEFAULT_LIGHTS;
 
-		Bitmap icon = BitmapFactory.decodeResource(context.getResources(), context.getResources().getIdentifier("icon", "drawable", context.getPackageName()));
+		Bitmap icon = BitmapFactory.decodeResource(context.getResources(), context.getResources().getIdentifier("icon", "mipmap", context.getPackageName()));
 
 		info.shown = true;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "localnotify",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "devkit": {
     "clientPaths": {
         "localNotify": "js"


### PR DESCRIPTION
we have our icons in mipmap, not in drawable anymore. so because of this even when u expand notification small icon was coming up